### PR TITLE
Minor Refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [1.21, 1.22]
+        go: [1.21, 1.22, 1.23]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -58,6 +58,7 @@ func (c *Compiler) compile(n ast.Node) (err error) {
 
 	case *ast.Null:
 		c.emit(vm.OpNull)
+
 	case *ast.IntegerLiteral:
 		obj := &types.Integer{Value: node.Value}
 		c.emit(vm.OpConstant, c.addConstant(obj))
@@ -250,7 +251,6 @@ func (c *Compiler) patchJump(pos int) {
 	for i := range ins {
 		c.instructions[pos+i] = ins[i]
 	}
-
 }
 
 func (c *Compiler) emit(op vm.Opcode, operands ...int) int {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/stevecallear/mexl
 
-go 1.21.1
+go 1.23.1

--- a/types/types.go
+++ b/types/types.go
@@ -65,14 +65,9 @@ func (i *Integer) Equal(o Object) bool {
 	if i == o {
 		return true
 	}
-	switch t := o.(type) {
-	case *Integer:
-		return i.Value == t.Value
-	case *Float:
-		return i.Value == int64(t.Value)
-	default:
-		return false
-	}
+
+	t, ok := o.(*Integer)
+	return ok && i.Value == t.Value
 }
 
 func (i *Integer) Type() Type {
@@ -87,14 +82,9 @@ func (f *Float) Equal(o Object) bool {
 	if f == o {
 		return true
 	}
-	switch t := o.(type) {
-	case *Float:
-		return f.Value == t.Value
-	case *Integer:
-		return f.Value == float64(t.Value)
-	default:
-		return false
-	}
+
+	t, ok := o.(*Float)
+	return ok && f.Value == t.Value
 }
 
 func (f *Float) Type() Type {
@@ -113,10 +103,9 @@ func (s *String) Equal(o Object) bool {
 	if s == o {
 		return true
 	}
-	if t, ok := o.(*String); ok {
-		return s.Value == t.Value
-	}
-	return false
+
+	t, ok := o.(*String)
+	return ok && s.Value == t.Value
 }
 
 func (s *String) Inspect() string {

--- a/types/types_test.go
+++ b/types/types_test.go
@@ -36,7 +36,7 @@ func TestInteger_Equal(t *testing.T) {
 		},
 		{
 			name: "not equal (float)",
-			cmp:  &types.Float{Value: 2.2},
+			cmp:  &types.Float{Value: 1.0},
 			exp:  false,
 		},
 		{
@@ -47,11 +47,6 @@ func TestInteger_Equal(t *testing.T) {
 		{
 			name: "equal (int)",
 			cmp:  &types.Integer{Value: 1},
-			exp:  true,
-		},
-		{
-			name: "equal (float)",
-			cmp:  &types.Float{Value: 1.0},
 			exp:  true,
 		},
 	}
@@ -100,7 +95,7 @@ func TestFloat_Equal(t *testing.T) {
 		},
 		{
 			name: "not equal (int)",
-			cmp:  &types.Integer{Value: 2},
+			cmp:  &types.Integer{Value: 1},
 			exp:  false,
 		},
 		{
@@ -111,11 +106,6 @@ func TestFloat_Equal(t *testing.T) {
 		{
 			name: "equal (pointer)",
 			cmp:  sut,
-			exp:  true,
-		},
-		{
-			name: "equal (int)",
-			cmp:  &types.Integer{Value: 1},
 			exp:  true,
 		},
 		{

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -223,18 +223,20 @@ func (vm *VM) execBinaryStringOp(op Opcode, left, right types.Object) error {
 }
 
 func (vm *VM) execEqualityComparison(op Opcode) error {
-	right := vm.pop()
-	left := vm.pop()
+	r := vm.pop()
+	l := vm.pop()
+
+	l, r = types.Coerce(l, r)
 
 	switch op {
 	case OpEqual:
-		vm.push(boolToObject(left.Equal(right)))
+		vm.push(boolToObject(l.Equal(r)))
 
 	case OpNotEqual:
-		vm.push(boolToObject(!left.Equal(right)))
+		vm.push(boolToObject(!l.Equal(r)))
 
 	default:
-		return fmt.Errorf("unknown equality comparison operator: %d (%s %s)", op, left.Type(), right.Type())
+		return fmt.Errorf("unknown equality comparison operator: %d (%s %s)", op, l.Type(), r.Type())
 	}
 
 	return nil


### PR DESCRIPTION
This PR refactors equality comparison to use type coercion. This allows the type system to remain strict, deferring to the VM to ensure that the appropriate types are being compared.