### PR TITLE
Index Op Behaviour

### DIFF
--- a/vm/vm.go
+++ b/vm/vm.go
@@ -456,10 +456,19 @@ func (vm *VM) execIndexExpression() error {
 	left := vm.pop()
 
 	switch {
+	case left.Type() == types.TypeNull && index.Type() == types.TypeInteger:
+		vm.push(objNull)
+
 	case left.Type() == types.TypeArray && index.Type() == types.TypeInteger:
 		a := left.(types.Array)
 		i := index.(*types.Integer).Value
-		vm.push(a[i])
+
+		if i >= 0 && int(i) < len(a) {
+			vm.push(a[i])
+		} else {
+			vm.push(objNull)
+		}
+
 	default:
 		return fmt.Errorf("index operator not supported: %s", left.Type())
 	}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -178,8 +178,23 @@ func TestArrays(t *testing.T) {
 		},
 		{
 			name: "index operator",
-			prog: compile(`[1, 2, 3][1]`),
+			prog: compile("[1, 2, 3][1]"),
 			exp:  2,
+		},
+		{
+			name: "index operator out of range (positive)",
+			prog: compile("[1][1]"),
+			exp:  nil,
+		},
+		{
+			name: "index operator out of range (negative)",
+			prog: compile("[1][-1]"),
+			exp:  nil,
+		},
+		{
+			name: "index operator on null",
+			prog: compile("null[0]"),
+			exp:  nil,
 		},
 	}
 


### PR DESCRIPTION
This PR alters the index operator behaviour which currently panics on out of range and returns an error for a null array.

The change results in null returns when indexes are out of range:
```
out, err := mexl.Eval("[1][1]", nil) // out is null, err is nil
```
```
out, err := mexl.Eval("[1][-1]", nil) // out is null, err is nil
```

In addition null types return null for index operations:
```
out, err := mexl.Eval("x[0]", nil) // x is nil, out is null, err is nil
```
