### PR TITLE
Add JSON Unmarshal built in

### DIFF
--- a/parser/lexer/lexer.go
+++ b/parser/lexer/lexer.go
@@ -1,6 +1,8 @@
 package lexer
 
 import (
+	"strings"
+
 	"github.com/stevecallear/mexl/ast/token"
 )
 
@@ -11,23 +13,27 @@ type Lexer struct {
 	ch      byte
 }
 
-var keywords = map[string]token.Type{
-	"true":  token.True,
-	"false": token.False,
-	"and":   token.And,
-	"or":    token.Or,
-	"not":   token.Bang,
-	"eq":    token.Equal,
-	"ne":    token.NotEqual,
-	"lt":    token.LessThan,
-	"gt":    token.GreaterThan,
-	"le":    token.LessThanOrEqual,
-	"ge":    token.GreaterThanOrEqual,
-	"sw":    token.StartsWith,
-	"ew":    token.EndsWith,
-	"in":    token.In,
-	"null":  token.Null,
-}
+var (
+	keywords = map[string]token.Type{
+		"true":  token.True,
+		"false": token.False,
+		"and":   token.And,
+		"or":    token.Or,
+		"not":   token.Bang,
+		"eq":    token.Equal,
+		"ne":    token.NotEqual,
+		"lt":    token.LessThan,
+		"gt":    token.GreaterThan,
+		"le":    token.LessThanOrEqual,
+		"ge":    token.GreaterThanOrEqual,
+		"sw":    token.StartsWith,
+		"ew":    token.EndsWith,
+		"in":    token.In,
+		"null":  token.Null,
+	}
+
+	escapeReplacer = strings.NewReplacer(`\"`, `"`, `\\`, `\`)
+)
 
 func New(input string) *Lexer {
 	l := &Lexer{input: input}
@@ -230,21 +236,36 @@ func (l *Lexer) readNumber() token.Token {
 }
 
 func (l *Lexer) readString() token.Token {
+	const quote = '"'
+	const escape = '\\'
+
 	p := l.pos + 1
 	t := token.Token{Type: token.String}
 
+loop:
 	for {
 		l.readChar()
-		if l.ch == 0 {
+		switch l.ch {
+		case 0:
 			t.Type = token.Illegal
-			break
-		}
-		if l.ch == '"' {
-			break
+			break loop
+
+		case quote:
+			break loop
+
+		case escape:
+			l.readChar()
+			switch l.ch {
+			case quote, escape:
+				// continue
+
+			default:
+				t.Type = token.Illegal
+			}
 		}
 	}
 
-	t.Literal = l.input[p:l.pos]
+	t.Literal = escapeReplacer.Replace(l.input[p:l.pos])
 	return t
 }
 

--- a/parser/lexer/lexer_test.go
+++ b/parser/lexer/lexer_test.go
@@ -125,9 +125,12 @@ func TestLexer_NextToken(t *testing.T) {
 		},
 		{
 			name:  "strings",
-			input: "\"abc 123\" \"abc",
+			input: `"abc 123" "\"abc\"" "\\" "\x" "abc`,
 			exp: []token.Token{
 				{Type: token.String, Literal: "abc 123"},
+				{Type: token.String, Literal: `"abc"`},
+				{Type: token.String, Literal: `\`},
+				{Type: token.Illegal, Literal: `\x`},
 				{Type: token.Illegal, Literal: "abc"},
 			},
 		},

--- a/vm/builtin.go
+++ b/vm/builtin.go
@@ -1,6 +1,7 @@
 package vm
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -65,6 +66,29 @@ var builtIns = map[string]types.Func{
 
 		default:
 			return nil, fmt.Errorf("upper: wrong arg type: %s, expected %s", args[0].Type(), types.TypeString)
+		}
+	},
+
+	"unmarshal": func(args ...types.Object) (types.Object, error) {
+		if err := expectArgsLen("unmarshal", args, 1); err != nil {
+			return nil, err
+		}
+
+		switch args[0].Type() {
+		case types.TypeNull:
+			return objNull, nil
+
+		case types.TypeString:
+			var m map[string]any
+			err := json.Unmarshal([]byte(args[0].(*types.String).Value), &m)
+			if err != nil {
+				return nil, err
+			}
+
+			return types.ToMap(m)
+
+		default:
+			return nil, fmt.Errorf("unmarshal: wrong arg type: %s, expected %s", args[0].Type(), types.TypeString)
 		}
 	},
 }

--- a/vm/builtin_test.go
+++ b/vm/builtin_test.go
@@ -84,6 +84,16 @@ func TestBuiltIn(t *testing.T) {
 			exp:  nil,
 		},
 		{
+			name: "unmarshal args count error",
+			prog: compile(`unmarshal("{}", "{}")`),
+			err:  true,
+		},
+		{
+			name: "unmarshal arg type error",
+			prog: compile(`unmarshal(1)`),
+			err:  true,
+		},
+		{
 			name: "unmarshal",
 			prog: compile(`unmarshal("{\"a\":1}")`),
 			exp:  map[string]any{"a": float64(1)},

--- a/vm/builtin_test.go
+++ b/vm/builtin_test.go
@@ -94,6 +94,11 @@ func TestBuiltIn(t *testing.T) {
 			err:  true,
 		},
 		{
+			name: "unmarshal error",
+			prog: compile(`unmarshal("{")`),
+			err:  true,
+		},
+		{
 			name: "unmarshal",
 			prog: compile(`unmarshal("{\"a\":1}")`),
 			exp:  map[string]any{"a": float64(1)},

--- a/vm/builtin_test.go
+++ b/vm/builtin_test.go
@@ -84,6 +84,16 @@ func TestBuiltIn(t *testing.T) {
 			exp:  nil,
 		},
 		{
+			name: "unmarshal",
+			prog: compile(`unmarshal("{\"a\":1}")`),
+			exp:  map[string]any{"a": float64(1)},
+		},
+		{
+			name: "unmarshal null",
+			prog: compile(`unmarshal(null)`),
+			exp:  nil,
+		},
+		{
 			name: "custom",
 			prog: compile(`reverse("abc")`),
 			env: map[string]types.Object{

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -402,19 +402,21 @@ func assertObject(t *testing.T, act types.Object, exp any) {
 		assertStringObject(t, act, exp)
 	case []any:
 		assertArrayObject(t, act, exp)
+	case map[string]any:
+		assertMapObject(t, act, exp)
 	default:
 		t.Errorf("got %s, expected %T", act.Type(), exp)
 	}
 }
 
-func assertNullObject(t *testing.T, act any) {
+func assertNullObject(t *testing.T, act types.Object) {
 	_, ok := act.(*types.Null)
 	if !ok {
 		t.Errorf("got %T, expected types.Null", act)
 	}
 }
 
-func assertIntegerObject(t *testing.T, act any, exp int64) {
+func assertIntegerObject(t *testing.T, act types.Object, exp int64) {
 	obj, ok := act.(*types.Integer)
 	if !ok {
 		t.Errorf("got %T, expected types.Integer", act)
@@ -426,7 +428,7 @@ func assertIntegerObject(t *testing.T, act any, exp int64) {
 	}
 }
 
-func assertFloatObject(t *testing.T, act any, exp float64) {
+func assertFloatObject(t *testing.T, act types.Object, exp float64) {
 	obj, ok := act.(*types.Float)
 	if !ok {
 		t.Errorf("got %T, expected types.Float", act)
@@ -438,7 +440,7 @@ func assertFloatObject(t *testing.T, act any, exp float64) {
 	}
 }
 
-func assertBooleanObject(t *testing.T, act any, exp bool) {
+func assertBooleanObject(t *testing.T, act types.Object, exp bool) {
 	obj, ok := act.(*types.Boolean)
 	if !ok {
 		t.Errorf("got %T, expected types.Boolean", act)
@@ -450,7 +452,7 @@ func assertBooleanObject(t *testing.T, act any, exp bool) {
 	}
 }
 
-func assertStringObject(t *testing.T, act any, exp string) {
+func assertStringObject(t *testing.T, act types.Object, exp string) {
 	obj, ok := act.(*types.String)
 	if !ok {
 		t.Errorf("got %T, expected types.String", act)
@@ -462,7 +464,7 @@ func assertStringObject(t *testing.T, act any, exp string) {
 	}
 }
 
-func assertArrayObject(t *testing.T, act any, exp []any) {
+func assertArrayObject(t *testing.T, act types.Object, exp []any) {
 	obj, ok := act.(types.Array)
 	if !ok {
 		t.Errorf("got %T, expected types.Array", act)
@@ -471,6 +473,22 @@ func assertArrayObject(t *testing.T, act any, exp []any) {
 
 	for i, exp := range exp {
 		assertObject(t, obj[i], exp)
+	}
+}
+
+func assertMapObject(t *testing.T, act types.Object, exp map[string]any) {
+	obj, ok := act.(types.Map)
+	if !ok {
+		t.Errorf("got %T, expected types.Map", act)
+		return
+	}
+
+	if act, exp := len(obj), len(exp); act != exp {
+		t.Errorf("got %d elements, expected %d", act, exp)
+	}
+
+	for k, exp := range exp {
+		assertObject(t, obj[k], exp)
 	}
 }
 


### PR DESCRIPTION
This PR adds a JSON unmarshal built in function. To allow the JSON to be parsed from user input, basic string escaping has been implemented to allow quotes.